### PR TITLE
Feat: Add crawling superior department classes

### DIFF
--- a/src/parser/crawl_department_code.py
+++ b/src/parser/crawl_department_code.py
@@ -75,8 +75,14 @@ def get_all_hakgwa_code(arr, year, hakgi, cd='A1000', action='expand', prefix=''
         stat = a_tag[1]['href'].split(',')[-1].replace(')', '').replace("'", '')
 
         # 1 의미 : 더 확장 가능 (대학을 의미), 2 의미 : 더 확장 불가 (학과를 의미)
+        # 더 확장이 되더라도 추가하기
         if stat == '1':
             new_pre = prefix + '-' + name
+
+            # 조직 데이터 추가
+            arr.append([new_pre[1:], code])
+
+            # 하위 조직으로 이동
             get_all_hakgwa_code(arr, year, hakgi, code, 'fold', new_pre, i + 1, len(all_elements) - i - 1)
         elif stat == '2':
             # 학과 데이터 추가


### PR DESCRIPTION
* 구현
  * 전공의 경우 상위 조직에서는 개설 과목이 없고, 최종 학과 단위로 개설 과목 만 크롤링 함.
  * 하지만 일부 상위 조직단위로 개설 과목이 있어서 해당 부분을 추가함.
* 테스트
  * 로컬에서 크롤링을 하고 데이터를 확인하여 누락된 과목이 잘 읽어오는 것을 확인 함.  